### PR TITLE
fixed: Add host default value as 'consul'

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -80,7 +80,7 @@ export default class IslandKeeper {
   }
 
   public init({
-    host,
+    host = 'consul',
     port,
     ns = 'game',
     token = process.env.ISLAND_CONSUL_TOKEN

--- a/src/spec/app-spec.ts
+++ b/src/spec/app-spec.ts
@@ -194,7 +194,7 @@ describe('etcd spec',() => {
   */
 
   it('초기화', done => {
-    IslandKeeper.getInst().init(process.env.ETCD_HOST || '192.168.99.100',  process.env.CONSUL_NAMESPACE || 'game');
+    IslandKeeper.getInst().init({host: process.env.ETCD_HOST || '192.168.99.100', ns: process.env.CONSUL_NAMESPACE || 'game'});
     if (IslandKeeper.getInst().initialized) done();
   });
 

--- a/src/spec/app-spec.ts
+++ b/src/spec/app-spec.ts
@@ -194,7 +194,7 @@ describe('etcd spec',() => {
   */
 
   it('초기화', done => {
-    IslandKeeper.getInst().init({host: process.env.ETCD_HOST || '192.168.99.100', ns: process.env.CONSUL_NAMESPACE || 'game'});
+    IslandKeeper.getInst().init({host: process.env.CONSUL_HOST || 'localhost', ns: process.env.CONSUL_NAMESPACE || 'game'});
     if (IslandKeeper.getInst().initialized) done();
   });
 


### PR DESCRIPTION
If there is no default host value when initialize, island-keeper will use 127.0.0.1:8500. 
Instead of 127.0.0.1:8500, changed to use 'consul' as default host value.