### PR TITLE
Changed default log level for npm test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "build": "gulp build",
         "watch": "gulp build && gulp watch",
         "clean": "gulp clean",
-        "test": "gulp build && jasmine"
+        "test": "gulp build && ISLAND_LOGGER_LEVEL=crit jasmine"
     },
     "dependencies": {
         "@types/bluebird": "3.5.5",


### PR DESCRIPTION
## Background
- When run npm test, jasmine displays success/fail message on the screen
- It makes debugging hard 
- It can be solved by adding ISLAND_LOGGER_LEVEL front of {scripts: {test: "jasmine"}} in package.json file 

```
{
  "scripts": {
    "test": "gulp build && ISLAND_LOGGER_LEVEL=crit jasmine"
  }
}
```