### PR TITLE
add log message at consul watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,34 +1,34 @@
 {
-    "name": "island-keeper",
-    "version": "2.6.0-dev",
-    "description": "island-keeper",
-    "main": "dist/index.js",
-    "typings": "dist/index.d.ts",
-    "author": "wokim <wonshikkim.kr@gmail.com>",
-    "contributors": [
-        "heycalmdown <hey.calmdown@gmail.com>"
-    ],
-    "scripts": {
-        "prepublish": "gulp build",
-        "build": "gulp build",
-        "watch": "gulp build && gulp watch",
-        "clean": "gulp clean",
-        "test": "gulp build && ISLAND_LOGGER_LEVEL=crit jasmine"
-    },
-    "dependencies": {
-        "@types/bluebird": "3.5.5",
-        "@types/consul": "^0.23.30",
-        "@types/jasmine": "^2.5.37",
-        "@types/lodash": "4.14.56",
-        "@types/node": "^6.0.46",
-        "bluebird": "^3.4.6",
-        "consul": "^0.25.0",
-        "island-loggers": "^1.1.0",
-        "lodash": "^4.16.0",
-        "source-map-support": "^0.4.2"
-    },
-    "devDependencies": {
-        "gulp": "^3.9.1",
-        "std-mocks": "^1.0.1"
-    }
+  "name": "island-keeper",
+  "version": "2.7.0-dev",
+  "description": "island-keeper",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "author": "wokim <wonshikkim.kr@gmail.com>",
+  "contributors": [
+    "heycalmdown <hey.calmdown@gmail.com>"
+  ],
+  "scripts": {
+    "prepublish": "gulp build",
+    "build": "gulp build",
+    "watch": "gulp build && gulp watch",
+    "clean": "gulp clean",
+    "test": "gulp build && ISLAND_LOGGER_LEVEL=crit jasmine"
+  },
+  "dependencies": {
+    "@types/bluebird": "3.5.5",
+    "@types/consul": "^0.23.30",
+    "@types/jasmine": "^2.5.37",
+    "@types/lodash": "4.14.56",
+    "@types/node": "^6.0.46",
+    "bluebird": "^3.4.6",
+    "consul": "^0.25.0",
+    "island-loggers": "^1.1.0",
+    "lodash": "^4.16.0",
+    "source-map-support": "^0.4.2"
+  },
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "std-mocks": "^1.0.1"
+  }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -349,7 +349,7 @@ public unregisterIsland(name: string, value: { hostname: string, port: any, patt
     });
 
     const changeHandler = (data, response) => {
-      logger.notice(`consul watch - changeHandler ${data.length} `);
+      logger.notice(`consul watch - changeHandler ${data.length}`);
       IslandKeeper.logAhead('IslandKeeper.watchEndpoints', {
         'Headers': response.headers,
         'Changes': data


### PR DESCRIPTION
There is an issue where too many requests from 'island' to 'consul'  using 'island-keeper'. (support/stt-issues/issues/#795)

So I add notice log to the most suspicious code.