### PR TITLE
guard consecutive error  RELEASE_CANDIDATE

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -45,6 +45,7 @@ export default class IslandKeeper {
   private static instance: IslandKeeper;
   private static serviceName: string;
   private static willCheckEndpoint: boolean = process.env.ISLAND_KEEPER_ENDPOINT_CHECK === 'true';
+  private static watcherErrorLimitCount: number = process.env.ISLAND_WATCH_LIMIT || 10;
 
   private ns: string;
   private consul: Consul.Consul;
@@ -52,6 +53,7 @@ export default class IslandKeeper {
   private intervalIds: { [name: string]: any } = {};
   private endpoints: any = {};
   private promiseEndpoints: Promise<any>;
+  private watchErrorCount = 0;
 
   public get initialized() { return this._initialized; }
 
@@ -342,32 +344,35 @@ public unregisterIsland(name: string, value: { hostname: string, port: any, patt
     const watcher = this.consul.watch({
       method: this.consul.kv.get,
       options: {
-        // FIXME @types/consul의 Watch.Options에는 key가 없나본데 어디 문젠지 확인
-        // @kson //2016-11-14
         key: endpointPrefix,
         recurse: true
-      } as Consul.CommonOptions //< 이거
+      } as Consul.Kv.GetOptions
     });
 
     const changeHandler = (data, response) => {
-      // const consulIndex: number = +response.headers['x-consul-index'];
-      const changes = _.remove(data, (item) => {
-        // FIXME: 가끔 놓쳐지는 endpoints들이 발견되었다. 그래서 지금은 안전하게 몽땅 다시 등록함. 딱히 성능 문제 없음.
-        return true; // consulIndex == item['CreateIndex'] || consulIndex == item['ModifyIndex'];
-      });
-
       IslandKeeper.logAhead('IslandKeeper.watchEndpoints', {
         'Headers': response.headers,
         'Changes': data
       });
-      for (var i=0; i<changes.length; i++) {
-        const item = changes[i];
+      for (var i=0; i<data.length; i++) {
+        const item = data[i];
         const key = item['Key'].substring(endpointPrefix.length);
         const value = JSON.parse(item['Value']);
         handler(key, <T>value);
       }
+      this.watchErrorCount = 0;
     };
     watcher.on('change', changeHandler);
+    watcher.on('error', async err => {
+      try {
+        await watcher.end();
+      } catch(err1) {}
+
+      if (++this.watchErrorCount > IslandKeeper.watcherErrorLimitCount) {
+        throw err;
+      }
+      this.watchEndpoints(handler);
+    })
     return watcher;
   }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -355,7 +355,7 @@ public unregisterIsland(name: string, value: { hostname: string, port: any, patt
         'Headers': response.headers,
         'Changes': data
       });
-      for (var i=0; i<data.length; i++) {
+      for (let i=0; i<data.length; i++) {
         const item = data[i];
         const key = item['Key'].substring(endpointPrefix.length);
         const value = JSON.parse(item['Value']);

--- a/src/app.ts
+++ b/src/app.ts
@@ -350,6 +350,7 @@ public unregisterIsland(name: string, value: { hostname: string, port: any, patt
     });
 
     const changeHandler = (data, response) => {
+      data = data || [];
       IslandKeeper.logAhead('IslandKeeper.watchEndpoints', {
         'Headers': response.headers,
         'Changes': data

--- a/src/app.ts
+++ b/src/app.ts
@@ -45,7 +45,7 @@ export default class IslandKeeper {
   private static instance: IslandKeeper;
   private static serviceName: string;
   private static willCheckEndpoint: boolean = process.env.ISLAND_KEEPER_ENDPOINT_CHECK === 'true';
-  private static watcherErrorLimitCount: number = process.env.ISLAND_WATCH_LIMIT || 10;
+  private static watcherErrorLimitCount: number = parseInt(process.env.ISLAND_WATCH_LIMIT || 10, 10);
 
   private ns: string;
   private consul: Consul.Consul;


### PR DESCRIPTION
It is guarded when happen error such as dns resolving failure when consul watching.

If these errors occur consecutively, other problems may occur.

If so, it will throw an error.

========= KR ==========

consul watch 중에 dns resolving 실패와 같은 에러가 발생할때를 가드합니다.
지속적으로 watch가 실패할 경우 다른 문제를 야기할 수 있습니다.
해당 island의 watch하는 정보가 부정확하는 하게 됨.

지속적으로 watch가 실패할 경우 island Keeper 는 error를 throw합니다.

이 값은 process.env.ISLAND_WATCH_LIMIT으로 정의될 수 있으며 default 값은 10입니다.