### PR TITLE
fixed registerEndpoint bug

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -304,6 +304,7 @@ public unregisterIsland(name: string, value: { hostname: string, port: any, patt
     opts.island = IslandKeeper.serviceName;
     opts.checksum = this.checksum(JSON.stringify(opts));
     return this.getKey(endpointKey).then(async res => {
+      res = res || {Value: {}};
       const prevChecksum = JSON.parse(res.Value).checksum;
       if (prevChecksum === opts.checksum) {
         return;


### PR DESCRIPTION
fixed if getKey is undefined
```
failed to initialize TypeError: Cannot read property 'Value' of undefined
    at IslandKeeper.<anonymous> (/app/be/service/node_modules/island-keeper/src/app.ts:307:42)
    at next (native)
    at /app/be/service/node_modules/island-keeper/dist/app.js:7:65
    at new WrappedPromise (/app/be/service/node_modules/async-listener/es6-wrapped-promise.js:13:18)
    at __awaiter (/app/be/service/node_modules/island-keeper/dist/app.js:3:12)
    at getKey.then (/app/be/service/node_modules/island-keeper/src/app.ts:306:51)
    at propagateAslWrapper (/app/be/service/node_modules/async-listener/index.js:478:23)
    at /app/be/service/node_modules/async-listener/glue.js:188:31
    at /app/be/service/node_modules/async-listener/index.js:515:70
    at /app/be/service/node_modules/async-listener/glue.js:188:31
    at process._tickDomainCallback (internal/process/next_tick.js:129:7)
```