### PR TITLE
refact: modify handler for watcher's  error

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -359,8 +359,9 @@ public unregisterIsland(name: string, value: { hostname: string, port: any, patt
       } catch (err1) {}
 
       if (++this.watchErrorCount > IslandKeeper.watcherErrorLimitCount) {
-        throw err;
+        logger.crit(`no longer possible to use watcher. please checking consul connection or restart island service`);
       }
+      await Bluebird.delay(500);
       this.watchEndpoints(handler);
     });
     return watcher;


### PR DESCRIPTION
# history
* If the consul dies, the watcher will regenerate quickly and the watcher may no longer be created.
* Modify the error in detail and add delay to increase the time that can be restarted